### PR TITLE
Add "customisation" to British English word list

### DIFF
--- a/.github/workflows/en_GB_wordlist
+++ b/.github/workflows/en_GB_wordlist
@@ -338,6 +338,7 @@
 \bcrystallising\b
 \bcudgelled\b
 \bcudgelling\b
+\bcustomisation\b
 \bcustomise\b
 \bcustomised\b
 \bcustomises\b


### PR DESCRIPTION
This PR adds a word that's been found to be missing from the British English word list/test:
"customisation".