### PR TITLE
Flag outdated content for readers

### DIFF
--- a/content/configuring/anomaly.md
+++ b/content/configuring/anomaly.md
@@ -5,6 +5,10 @@ chapter: false
 weight: 10
 ---
 
+{{% notice note %}}
+**The content on this page may be outdated.** We are currently in the process of rewriting all of our documentation: please bear with us while we update our older content.
+{{% /notice %}}
+
 {{% notice warning %}}
 From version 3.0 onwards, Anomaly Scoring is the default detection mode. Traditional detection mode is discouraged.
 {{% /notice %}}

--- a/content/deployment/install.md
+++ b/content/deployment/install.md
@@ -5,6 +5,10 @@ chapter: false
 weight: 20
 ---
 
+{{% notice note %}}
+**The content on this page may be outdated.** We are currently in the process of rewriting all of our documentation: please bear with us while we update our older content.
+{{% /notice %}}
+
 If you need mode information than the one in the [quickstart guide]({{< ref "quickstart.md" >}}), here we extend with additional details so keep reading.
 
 Below you should find all the information you need to properly install

--- a/content/deployment/quickstart.md
+++ b/content/deployment/quickstart.md
@@ -5,6 +5,10 @@ chapter: false
 weight: 10
 ---
 
+{{% notice note %}}
+**The content on this page may be outdated.** We are currently in the process of rewriting all of our documentation: please bear with us while we update our older content.
+{{% /notice %}}
+
 Welcome to the OWASP Core RuleSet (CRS) quickstart guide. We will
 attempt to get you up and running with CRS as quick as possible. This
 guide assumes ModSecurity is already working. If you are unsure see the

--- a/content/resources/_index.md
+++ b/content/resources/_index.md
@@ -8,6 +8,10 @@ chapter: true
 
 # Additional Resources
 
+{{% notice note %}}
+**The content on this page may be outdated.** We are currently in the process of rewriting all of our documentation: please bear with us while we update our older content.
+{{% /notice %}}
+
 ## Free and Open-Source Community Help
 
 - [Core Rule Set GitHub repository](https://github.com/coreruleset/coreruleset). Open issues for bugs, report false positives, and access the source code.

--- a/content/rules/creating.md
+++ b/content/rules/creating.md
@@ -5,6 +5,10 @@ weight = 9
 pre = "<b>9. </b>"
 +++
 
+{{% notice note %}}
+**The content on this page may be outdated.** We are currently in the process of rewriting all of our documentation: please bear with us while we update our older content.
+{{% /notice %}}
+
 ## Making Rules
 
 ### The Basic Synatax

--- a/content/rules/metadata.md
+++ b/content/rules/metadata.md
@@ -5,6 +5,10 @@ weight = 10
 pre = "<b>10. </b>"
 +++
 
+{{% notice note %}}
+**The content on this page may be outdated.** We are currently in the process of rewriting all of our documentation: please bear with us while we update our older content.
+{{% /notice %}}
+
 ## OWASP CRS Metadata
 
 OWASP CRS 3.x includes several pieces of metadata within rules. Not

--- a/content/rules/ruleid.md
+++ b/content/rules/ruleid.md
@@ -5,6 +5,10 @@ weight = 1
 pre = "<b>1. </b>"
 +++
 
+{{% notice note %}}
+**The content on this page may be outdated.** We are currently in the process of rewriting all of our documentation: please bear with us while we update our older content.
+{{% /notice %}}
+
 ## Why do rule IDs matter?
 
 Each rule added to a ModSecurity instance must have a unique ID (in

--- a/content/rules/rules.md
+++ b/content/rules/rules.md
@@ -5,6 +5,10 @@ weight = 3
 pre = "<b>3. </b>"
 +++
 
+{{% notice note %}}
+**The content on this page may be outdated.** We are currently in the process of rewriting all of our documentation: please bear with us while we update our older content.
+{{% /notice %}}
+
 # What's In The Rules
 
 | **REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example**

--- a/content/rules/testing.md
+++ b/content/rules/testing.md
@@ -6,6 +6,10 @@ weight = 2
 pre = "<b>2. </b>"
 +++
 
+{{% notice note %}}
+**The content on this page may be outdated.** We are currently in the process of rewriting all of our documentation: please bear with us while we update our older content.
+{{% /notice %}}
+
 Shipped with the ruleset are a number of different tools. One of these
 tools are the regression testing framework for OWASP CRS. For testing we
 use WTF (WAF Testing Framework). This framework allows us to specify


### PR DESCRIPTION
This PR adds a note to the top of each page which has not been rewritten/updated/checked yet, so that readers know which parts of the documentation can currently be relied on to be up to date and accurate.