### PR TITLE
Standardise on using "libModSecurity"

### DIFF
--- a/content/development/useful_tools.md
+++ b/content/development/useful_tools.md
@@ -49,7 +49,7 @@ A ModSecurity config parser. Makes it possible to modify SecRules en masse, for 
 
 https://github.com/digitalwave/msc_retest
 
-An invaluable tool for testing how regular expressions behave *and perform* in both `mod_security2` (the Apache module) and `libmodsecurity` (ModSecurity v3).
+An invaluable tool for testing how regular expressions behave *and perform* in both `mod_security2` (the Apache module) and `libModSecurity` (ModSecurity v3).
 
 ## Regexploit
 


### PR DESCRIPTION
PR standardises on the use of "libModSecurity". I thought I'd written more instances of it, but there's only one use to correct!