### PR TITLE
Tidy up (pass 2)

### DIFF
--- a/content/concepts/plugins.md
+++ b/content/concepts/plugins.md
@@ -121,41 +121,4 @@ Available plugins include:
 
 ## How to Write a Plugin
 
-### Is a Plugin the Right Approach for a Given Rule Problem?
-
-This is the first and most important question to ask.
-
-CRS is a generic rule set. The rule set has no awareness of the particular setup it finds itself deployed in. As such, the rules are written with caution and administrators are given the ability to steer the behavior of CRS by setting the anomaly threshold accordingly. *An administrator writing their own rules knows a lot more about their specific setup*, so there's probably no need to be as cautious. It's also probably futile to write anomaly scoring rules in this situation. Anomaly scoring adds little value if an administrator knows that everybody issuing a request to `/no-access`, for example, is an attacker.
-
-In such a situation, it's better to write a simple deny-rule that blocks said requests. There's no need for a plugin in most situations.
-
-### Plugin Writing Guidance
-
-When there really *is* a good use case for a plugin, it's recommended to start with a clone of the dummy plugin. It's well documented and a good place to start from.
-
-Plugins are a new idea for CRS. As such, there aren't currently any strict rules about what a plugin is and isn't allowed to do. There are definitely fewer rules and restrictions for writing plugin rules than for writing a mainline CRS rule, which is becoming increasingly strict as the project evolves. This means that it's basically possible to do anything in a plugin, especially when there's no plan to contribute the plugin to the CRS project.
-
-When it *is* planned to contribute a plugin back to the CRS project, the following guidance will help:
-
-* Try to keep plugins separate. Try not to interfere with other plugins and make sure that any other plugin can run next to yours.
-* Be careful when interfering with CRS. It's easy to disrupt CRS by excluding essential rules or by messing with variables.
-* Keep an eye on performance and think of use cases.
-
-### Anomaly Scoring: Getting the Phases Right
-
-The anomaly scores are only initialized in the CRS rules file `REQUEST-901-INITIALIZATION.conf`. This happens in phase 1, but it still happens *after* a plugin's `*-before.conf` file has been executed for phase 1. As a consequence, if anomaly scores are set there then they'll be overwritten in CRS phase 1.
-
-The effect for phase 2 anomaly scoring in a plugin's `*-after.conf` file is similar. It happens after the CRS request blocking happens in phase 2. This can mean a plugin raises the anomaly score *after* the blocking decision. This might result in a higher anomaly score in the log file and confusion as to why the request was not blocked.
-
-What to do is as follows:
-
-* **Scoring in phase 1:** Put in the plugin's *After-File* (and be aware that early blocking won't work).
-* **Scoring in phase 2:** Put in the plugin's *Before-File*.
-
-## Quality Guarantee
-
-The official CRS plugins are separated from third party plugins. The rationale is to keep the quality of official plugins on par with the quality of the CRS project itself. It's not possible to guarantee the quality of third party plugins as their code is not under the control of the CRS project. Third party plugins should be examined and considered separately to decide whether their quality is sufficient for use in production.
-
-## How to Integrate a Plugin into the Official Registry
-
-Plugins should be developed and refined until they are production-ready. The next step is to open a pull request at the [plugin registry](https://github.com/coreruleset/plugin-registry). Any free rule ID range can be used for a new plugin. The plugin will then be reviewed and assigned a block of rule IDs. Afterwards, the plugin will be listed as a new third party plugin.
+For information on writing a new plugin, refer to the development documentation on [writing plugins]({{< ref "plugin_writing.md" >}}).

--- a/content/development/plugin_writing.md
+++ b/content/development/plugin_writing.md
@@ -4,3 +4,46 @@ weight: 40
 disableToc: false
 chapter: false
 ---
+
+> The CRS plugin mechanism allows the rule set to be extended in specific, experimental, or unusual ways. This page explains how to write a new plugin to extend CRS.
+
+## How to Write a Plugin
+
+### Is a Plugin the Right Approach for a Given Rule Problem?
+
+This is the first and most important question to ask.
+
+CRS is a generic rule set. The rule set has no awareness of the particular setup it finds itself deployed in. As such, the rules are written with caution and administrators are given the ability to steer the behavior of CRS by setting the anomaly threshold accordingly. *An administrator writing their own rules knows a lot more about their specific setup*, so there's probably no need to be as cautious. It's also probably futile to write anomaly scoring rules in this situation. Anomaly scoring adds little value if an administrator knows that everybody issuing a request to `/no-access`, for example, is an attacker.
+
+In such a situation, it's better to write a simple deny-rule that blocks said requests. There's no need for a plugin in most situations.
+
+### Plugin Writing Guidance
+
+When there really *is* a good use case for a plugin, it's recommended to start with a clone of the dummy plugin. It's well documented and a good place to start from.
+
+Plugins are a new idea for CRS. As such, there aren't currently any strict rules about what a plugin is and isn't allowed to do. There are definitely fewer rules and restrictions for writing plugin rules than for writing a mainline CRS rule, which is becoming increasingly strict as the project evolves. This means that it's basically possible to do anything in a plugin, especially when there's no plan to contribute the plugin to the CRS project.
+
+When it *is* planned to contribute a plugin back to the CRS project, the following guidance will help:
+
+* Try to keep plugins separate. Try not to interfere with other plugins and make sure that any other plugin can run next to yours.
+* Be careful when interfering with CRS. It's easy to disrupt CRS by excluding essential rules or by messing with variables.
+* Keep an eye on performance and think of use cases.
+
+### Anomaly Scoring: Getting the Phases Right
+
+The anomaly scores are only initialized in the CRS rules file `REQUEST-901-INITIALIZATION.conf`. This happens in phase 1, but it still happens *after* a plugin's `*-before.conf` file has been executed for phase 1. As a consequence, if anomaly scores are set there then they'll be overwritten in CRS phase 1.
+
+The effect for phase 2 anomaly scoring in a plugin's `*-after.conf` file is similar. It happens after the CRS request blocking happens in phase 2. This can mean a plugin raises the anomaly score *after* the blocking decision. This might result in a higher anomaly score in the log file and confusion as to why the request was not blocked.
+
+What to do is as follows:
+
+* **Scoring in phase 1:** Put in the plugin's *After-File* (and be aware that early blocking won't work).
+* **Scoring in phase 2:** Put in the plugin's *Before-File*.
+
+## Quality Guarantee
+
+The official CRS plugins are separated from third party plugins. The rationale is to keep the quality of official plugins on par with the quality of the CRS project itself. It's not possible to guarantee the quality of third party plugins as their code is not under the control of the CRS project. Third party plugins should be examined and considered separately to decide whether their quality is sufficient for use in production.
+
+## How to Integrate a Plugin into the Official Registry
+
+Plugins should be developed and refined until they are production-ready. The next step is to open a pull request at the [plugin registry](https://github.com/coreruleset/plugin-registry). Any free rule ID range can be used for a new plugin. The plugin will then be reviewed and assigned a block of rule IDs. Afterwards, the plugin will be listed as a new third party plugin.

--- a/content/operation/containers.md
+++ b/content/operation/containers.md
@@ -5,4 +5,24 @@ disableToc: false
 chapter: false
 ---
 
-## Docker
+The CRS project maintains two sets of Docker images: 'CRS with ModSecurity' and 'standalone ModSecurity'.
+
+A full operational guide on how to use and deploy these images will be written in the future. In the meantime, refer to the GitHub README pages for more information on how to use these official container images.
+
+## ModSecurity Core Rule Set Docker Image
+
+https://github.com/coreruleset/modsecurity-crs-docker
+
+A Docker image supporting the latest stable CRS release on: 
+
+- the latest stable ModSecurity v2 on Apache
+- the latest stable ModSecurity v3 on Nginx
+
+## ModSecurity Docker Image
+
+https://github.com/coreruleset/modsecurity-docker
+
+A Docker image supporting:
+
+- the latest stable ModSecurity v2 on Apache
+- the latest stable ModSecurity v3 on Nginx

--- a/content/operation/known_issues.md
+++ b/content/operation/known_issues.md
@@ -5,12 +5,11 @@ disableToc: false
 chapter: false
 ---
 
-- There are still **false positives** for standard web applications in
-  the default install (paranoia level 1). Please [report these](https://github.com/coreruleset/coreruleset/issues/new/choose) on GitHub when you encounter them.
-  False positives from paranoia level 2 and up are less interesting,
-  as we expect users to write exclusion rules for their alerts in
-  the higher paranoia levels. Nevertheless, feel free to report them
-  and we will try to find a generic solution for your alert.
+> There are some *known issues* with CRS and some of its compatible WAF engines. This page describes these issues. Get in touch if you think something is missing.
+
+- There are still **false positives** for standard web applications in the default install (paranoia level 1). Please [report these on GitHub](https://github.com/coreruleset/coreruleset/issues/new/choose) if and when encountered.
+
+  False positives from paranoia level 2 and higher are considered to be less interesting, as it is expected that users will write exclusion rules for their alerts in the higher paranoia levels. Nevertheless, false positives from higher paranoia levels can still be reported and the CRS project will try to find a generic solution for them.
 
 - **Apache** may give an error on startup when the CRS is loaded:
 
@@ -18,9 +17,7 @@ chapter: false
   AH00111: Config variable ${[^} is not defined
   ```
 
-  It appears Apache tries to be smart trying to evaluate a config variable.
-  This notice should be a warning and can be safely ignored.
-  We have investigated the problem and did not find a solution yet.
+  It appears that Apache tries to be smart by trying to evaluate a config variable. This notice should be a warning and can be safely ignored. The problem has been investigated and a solution has not been found yet.
 
 - **ModSecurity 3.0.0-3.0.2** will give an error:
 
@@ -28,46 +25,31 @@ chapter: false
   Expecting an action, got: ctl:requestBodyProcessor=URLENCODED"`
   ```
 
-  Support for the URLENCODED body processor was only added in ModSecurity 3.0.3.
-  Please upgrade your ModSecurity to 3.0.3 or higher.
+  Support for the URLENCODED body processor was only added in ModSecurity 3.0.3. To resolve this, upgrade to ModSecurity 3.0.3 or higher.
 
-- **Debian** up to and including Jessie lacks YAJL/JSON support in ModSecurity,
-  which causes the following error in the Apache ErrorLog or SecAuditLog:
+- **Debian** releases up to and including Jessie lack YAJL/JSON support in ModSecurity. This causes the following error in the Apache ErrorLog or SecAuditLog:
+
   ```
   ModSecurity: JSON support was not enabled.
   ```
-  JSON support was enabled in Debian's package version 2.8.0-4 (Nov 2014).
-  You can either use backports.debian.org to install the latest ModSecurity
-  release or disable rule id 200001.
 
-- **Apache 2.4 prior to 2.4.11** is affected by a bug in parsing multi-line
-  configuration directives, which causes Apache to fail during startup
-  with an error such as:
+  JSON support was enabled in Debian's package version 2.8.0-4 (Nov 2014). To resolve this, it is possible to either use `backports.debian.org` to install the latest ModSecurity
+  release or to disable the rule with ID 200001.
+
+- **Apache 2.4 prior to 2.4.11** is affected by a bug in parsing multi-line configuration directives, which causes Apache to fail during startup with an error such as:
 
   ```plaintext
   Error parsing actions: Unknown action: \\
   Action 'configtest' failed.`
   ```
 
-  This bug is known to plague RHEL/Centos 7 below v7.4 or
-  httpd v2.4.6 release 67 and Ubuntu 14.04 LTS users.
-  https://bz.apache.org/bugzilla/show_bug.cgi?id=55910
-  We advise to upgrade your Apache version. If upgrading is not possible,
-  we have provided a script in the util/join-multiline-rules directory
-  which converts the rules into a format that works around the bug.
-  You have to re-run this script whenever you modify or update
-  the CRS rules.
+  This bug is known to plague RHEL/Centos 7 below v7.4 or httpd v2.4.6 release 67 and Ubuntu 14.04 LTS users. (The original bug report can be found at https://bz.apache.org/bugzilla/show_bug.cgi?id=55910\).
 
-- As of CRS version 3.0.1, support has been added for the `application/soap+xml` MIME
-  type by default, as specified in RFC 3902. OF IMPORTANCE, application/soap+xml is
-  indicative that XML will be provided. In accordance with this, ModSecurity's XML
-  Request Body Processor should also be configured to support this MIME type. Within
-  the ModSecurity project, [commit 5e4e2af](https://github.com/SpiderLabs/ModSecurity/commit/5e4e2af7a6f07854fee6ed36ef4a381d4e03960e)
-  has been merged to support this endeavor. However, if you are running a modified or
-  preexisting version of the modsecurity.conf provided by this repository, you may
-  wish to upgrade rule '200000' accordingly. The rule now appears as follows:
+  It is advisable to upgrade an affected Apache version. If upgrading is not possible, the CRS project provides a script in the `util/join-multiline-rules` directory which converts the rules into a format that works around the bug. This script must be re-run whenever the CRS rules are modified or updated.
+
+- As of CRS version 3.0.1, support has been added for the `application/soap+xml` MIME type by default, as specified in RFC 3902. **OF IMPORTANCE:** application/soap+xml is indicative that XML will be provided. In accordance with this, ModSecurity's XML request body processor should also be configured to support this MIME type. Within the ModSecurity project, [commit 5e4e2af](https://github.com/SpiderLabs/ModSecurity/commit/5e4e2af7a6f07854fee6ed36ef4a381d4e03960e) has been merged to support this endeavor. However, if running a modified or preexisting version of the modsecurity.conf file provided by this repository, it is a good idea to upgrade rule '200000' accordingly. The rule now appears as follows:
+
   ```
   SecRule REQUEST_HEADERS:Content-Type "(?:application(?:/soap\+|/)|text/)xml" \
     "id:'200000',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=XML"
   ```
-

--- a/content/operation/log_handling.md
+++ b/content/operation/log_handling.md
@@ -4,3 +4,5 @@ weight: 30
 disableToc: false
 chapter: false
 ---
+
+A full operational guide on how to handle and consume the logs emitted by CRS and its compatible WAF engines will be written in the future.


### PR DESCRIPTION
This PR:

- tidies up the known issues page
- adds basic content to all remaining empty pages
- splits the plugin documentation across the "Concepts" page and the previously empty "Writing Plugins" page

No new content, just fixes and tidying.