### PR TITLE
Add dummy Rule Writing page pointing to Contrib.Gu

### DIFF
--- a/content/development/plugin_writing.md
+++ b/content/development/plugin_writing.md
@@ -1,6 +1,6 @@
 ---
 title: Writing Plugins
-weight: 40
+weight: 50
 disableToc: false
 chapter: false
 ---

--- a/content/development/rule_writing.md
+++ b/content/development/rule_writing.md
@@ -1,0 +1,18 @@
+---
+title: Writing Rules
+weight: 20
+disableToc: false
+chapter: false
+---
+
+> From years of experience, the CRS project has assembled a wealth of knowledge and advice on how to write clear and efficient WAF rules, as this page outlines.
+
+The CRS project's advice on rule writing is contained within the [contribution guidelines]({{< ref "contribution_guidelines.md" >}}), a document which can also be found in plain text form in CRS releases for offline reference. The guidelines contain invaluable guidance and tips on how to write rules, including:
+
+- effective regular expression writing
+- consistent formatting and indentation
+- rule action order
+- CRS paranoia level rule compliance
+- writing rule tests
+
+While some of the guidelines are specific to writing rules for inclusion in CRS, following the guidelines will help with the creation of *any* rule set by ensuring that rules are clear, efficient, easy to read, and easy to maintain.

--- a/content/development/sandbox.md
+++ b/content/development/sandbox.md
@@ -1,6 +1,6 @@
 ---
 title: Using the CRS Sandbox
-weight: 50
+weight: 60
 disableToc: false
 chapter: false
 ---

--- a/content/development/testing.md
+++ b/content/development/testing.md
@@ -1,6 +1,6 @@
 ---
 title: Testing the Rule Set
-weight: 30
+weight: 40
 disableToc: false
 chapter: false
 ---

--- a/content/development/useful_tools.md
+++ b/content/development/useful_tools.md
@@ -1,6 +1,6 @@
 ---
 title: Useful Tools
-weight: 20
+weight: 30
 disableToc: false
 chapter: false
 ---


### PR DESCRIPTION
PR adds a dummy Rule Writing page which points to the Contribution Guidelines page.

This makes the rule writing advice more visible, as a new visitor to the site might not find the rule writing tips which are buried within the Contribution Guidelines.