### PR TITLE
Add chain rule commenting guidance

### DIFF
--- a/content/development/contribution_guidelines.md
+++ b/content/development/contribution_guidelines.md
@@ -38,6 +38,7 @@ chapter: false
 * No trailing whitespace at EOL.
 * No trailing blank lines at EOF (only the required single EOF newline character is allowed).
 * Add comments where possible and clearly explain any new rules.
+* Comments must not appear between chained rules and should instead be placed before the start of a rule chain.
 * Adhere to an 80 character line length limit where possible.
 * All [chained rules](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual(v2.x)#chain) should be indented like so, for readability:
 ```


### PR DESCRIPTION
PR adds newly agreed guidance about commenting chained rules.