### PR TITLE
Remove reference to the old vanilla ModSec contai.

### DIFF
--- a/content/operation/containers.md
+++ b/content/operation/containers.md
@@ -5,24 +5,15 @@ disableToc: false
 chapter: false
 ---
 
-The CRS project maintains two sets of Docker images: 'CRS with ModSecurity' and 'standalone ModSecurity'.
+The CRS project maintains a set of 'CRS with ModSecurity' Docker images.
 
-A full operational guide on how to use and deploy these images will be written in the future. In the meantime, refer to the GitHub README pages for more information on how to use these official container images.
+A full operational guide on how to use and deploy these images will be written in the future. In the meantime, refer to the GitHub README page for more information on how to use these official container images.
 
 ## ModSecurity Core Rule Set Docker Image
 
 https://github.com/coreruleset/modsecurity-crs-docker
 
 A Docker image supporting the latest stable CRS release on: 
-
-- the latest stable ModSecurity v2 on Apache
-- the latest stable ModSecurity v3 on Nginx
-
-## ModSecurity Docker Image
-
-https://github.com/coreruleset/modsecurity-docker
-
-A Docker image supporting:
 
 - the latest stable ModSecurity v2 on Apache
 - the latest stable ModSecurity v3 on Nginx


### PR DESCRIPTION
PR removes the reference to the old, discontinued "ModSec only" containers.

The references to the current "CRS plus ModSec" containers remain. These are the only ones that should be used going forwards.