### PR TITLE
Add missing content and fix ref. man. link

### DIFF
--- a/content/development/contribution_guidelines.md
+++ b/content/development/contribution_guidelines.md
@@ -286,6 +286,8 @@ Whether optimizations make sense in a contribution is assessed for each case ind
 
 The rules in CRS are organized into **paranoia levels** (PLs) which makes it possible to define how aggressive CRS is. See the documentation on [paranoia levels](https://coreruleset.org/docs/concepts/paranoia_levels/) for an introduction and more detailed explanation.
 
+Each rule that is placed into a paranoia level must contain the tag `paranoia-level/N`, where *N* is the PL value, however this tag can only be added if the rule does **not** use the nolog action.
+
 The types of rules that are allowed at each paranoia level are as follows:
 
 **PL 0:**
@@ -303,7 +305,7 @@ The types of rules that are allowed at each paranoia level are as follows:
 
 **PL 2:**
 
-* [Chain](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual(v2.x)#chain) usage is allowed
+* [Chain](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-%28v2.x%29#chain) usage is allowed
 * Confirmed matches use score critical
 * Matches that cause false positives are limited to using scores notice or warning
 * Low false positive rates


### PR DESCRIPTION
This PR fixes issue #69.

Adds a missing comment on the contribution guidelines page that was applied to the CRS repo version but not the documentation version. Also fixes a broken link to the ModSecurity Reference Manual.