### PR TITLE
Correct typo in link to ModSecurity reference wiki

### DIFF
--- a/content/development/contribution_guidelines.md
+++ b/content/development/contribution_guidelines.md
@@ -40,7 +40,7 @@ chapter: false
 * Adhere to an 80 character line length limit where possible.
 * Add comments where possible and clearly explain any new rules.
 * Comments must not appear between chained rules and should instead be placed before the start of a rule chain.
-* All [chained rules](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual(v2.x)#chain) should be indented like so, for readability:
+* All [chained rules](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-(v2.x)#chain) should be indented like so, for readability:
 ```
 SecRule .. .. \
     "..."


### PR DESCRIPTION
PR corrects a single character typo which broke a hyperlink to the ModSecurity reference wiki regarding chain rules.