### PR TITLE
docs: document SecCollectionTimeout as part of plugin doc

### DIFF
--- a/content/concepts/plugins.md
+++ b/content/concepts/plugins.md
@@ -125,4 +125,4 @@ For information on writing a new plugin, refer to the development documentation 
 
 ## Collection Timeout
 
-CRS used to define `SecCollectionTimeout` in `crs-setup.conf` before but removed this setting with the introduction of plugins for CRS v4. That's because CRS itself does not work with collections anymore. However, for plugins, there may be a need to work with collections and maybe also to set a custom `SecCollectionTimeout` outside of the default 3600 seconds defined by the ModSecurity engine. If that's the case, the plugin should either set it in its configuration or indicate the desired value in the plugin documentation.
+If plugins need to work with collections and set a custom `SecCollectionTimeout` outside of the default 3600 seconds defined by the ModSecurity engine, the plugin should either set it in its configuration or indicate the desired value in the plugin documentation. CRS used to define `SecCollectionTimeout` in `crs-setup.conf` before but removed this setting with the introduction of plugins for CRS v4. That's because CRS itself does not work with collections anymore. 

--- a/content/concepts/plugins.md
+++ b/content/concepts/plugins.md
@@ -122,3 +122,7 @@ Available plugins include:
 ## How to Write a Plugin
 
 For information on writing a new plugin, refer to the development documentation on [writing plugins]({{< ref "plugin_writing.md" >}}).
+
+## Collection Timeout
+
+CRS used to define `SecCollectionTimeout` in `crs-setup.conf` before but removed this setting with the introduction of plugins for CRS v4. That's because CRS itself does not work with collections anymore. However, for plugins, there may be a need to work with collections and maybe also to set a custom `SecCollectionTimeout` outside of the default 3600 seconds defined by the ModSecurity engine. If that's the case, the plugin should either set it in its configuration or indicate the desired value in the plugin documentation.


### PR DESCRIPTION
Based on a [Oct 2023 CRS team decision](https://github.com/coreruleset/coreruleset/issues/3280#issuecomment-1744217375), I have added the `SecCollectionTimeout` documentation to the plugin section. Not sure this is the best place, though.

Feedback, reviews and advice welcome.