### PR TITLE
Update extended_install.md to fix syntax error of the `gpg --edit-key` command.

### DIFF
--- a/content/deployment/extended_install.md
+++ b/content/deployment/extended_install.md
@@ -150,7 +150,7 @@ If the signature was good then the verification succeeds. If a warning is displa
 To trust the CRS project's public key:
 
 ```bash
-gpg edit-key 36006F0E0BA167832158821138EEACA1AB8A6E72
+gpg --edit-key 36006F0E0BA167832158821138EEACA1AB8A6E72
 gpg> trust
 Your decision: 5 (ultimate trust)
 Are you sure: Yes


### PR DESCRIPTION
Originally there was a Syntax Error in the "To trust the CRS project's public key:" section, where the command `gpg --edit-key` was misspelled as `gpg edit-key`. We fixed this by making the final syntax `gpg --edit-key`. 

Before:
----------------------------------------
```bash
gpg edit-key 
----------------------------------------

After:
----------------------------------------
changed to:
```bash
gpg --edit-key
---------------------------------------