### PR TITLE
chore: add config for github-pages as subsite

### DIFF
--- a/config/github-pages/config.toml
+++ b/config/github-pages/config.toml
@@ -1,0 +1,2 @@
+baseURL = "https://coreruleset.org/docs/"
+publishDir = "public/docs"


### PR DESCRIPTION
## what

- add config option for being used as submodule


## why

- future gh-pages main website