### PR TITLE
fix: add permissions to dispatch job

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -78,6 +78,8 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: write # needed for triggering dispatch
     steps:
       - name: Dispatch to workflows
         run: |


### PR DESCRIPTION
Turns out dispatch needs to write contents. 🤷 