### PR TITLE
chore: update Hugo theme once per month only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,10 @@
     "local>coreruleset/renovate-config"
   ],
   "git-submodules": {
-    "enabled": true
+    "enabled": true,
+    "schedule": [
+      "on the first day of the month"
+    ]
   },
   "customManagers": [
     {


### PR DESCRIPTION
The Hugo theme is updated pretty regularly on the main branch. Reduce noise by updating the theme once per month only.