### PR TITLE
fix: remove duplicate h1 tags

### DIFF
--- a/content/concepts/_index.md
+++ b/content/concepts/_index.md
@@ -5,6 +5,4 @@ pre: "<b>2. </b>"
 chapter: true
 ---
 
-# How CRS Works
-
 Deep dive into core CRS concepts in this chapter.

--- a/content/deployment/_index.md
+++ b/content/deployment/_index.md
@@ -4,5 +4,3 @@ weight: 10
 pre: "<b>1. </b>"
 chapter: true
 ---
-
-# Getting CRS

--- a/content/development/_index.md
+++ b/content/development/_index.md
@@ -4,5 +4,3 @@ weight: 50
 pre: "<b>5. </b>"
 chapter: true
 ---
-
-# Development

--- a/content/development/testing.md
+++ b/content/development/testing.md
@@ -5,8 +5,6 @@ disableToc: false
 chapter: false
 ---
 
-# Testing for rule developers
-
 Well, you managed to write your rule, but now want to see if if can be added to the CRS? This document should help you to test it using the same tooling the project uses for its tests.
 
 CRS uses [go-ftw](https://github.com/coreruleset/go-ftw) to run test cases. **go-ftw** is the successor to the previously used test runner [ftw](https://github.com/coreruleset/ftw). The CRS project no longer uses **ftw** but it us still useful for running tests of older CRS versions.

--- a/content/miscellaneous/_index.md
+++ b/content/miscellaneous/_index.md
@@ -5,6 +5,4 @@ pre: "<b>7. </b>"
 chapter: true
 ---
 
-# Miscellaneous
-
 The content here doesn't fit anywhere else just yet. This whole section will probably be reworked and is only temporary.

--- a/content/operation/_index.md
+++ b/content/operation/_index.md
@@ -4,5 +4,3 @@ weight: 30
 pre: "<b>3. </b>"
 chapter: true
 ---
-
-# Operation

--- a/content/resources/_index.md
+++ b/content/resources/_index.md
@@ -5,8 +5,6 @@ pre: "<b>6. </b>"
 chapter: true
 ---
 
-# Additional Resources
-
 {{% notice note %}}
 **The content on this page may be outdated.** We are currently in the process of rewriting all of our documentation: please bear with us while we update our older content.
 {{% /notice %}}

--- a/content/rules/_index.md
+++ b/content/rules/_index.md
@@ -4,5 +4,3 @@ weight: 40
 pre: "<b>4. </b>"
 chapter: true
 ---
-
-# Rules

--- a/content/rules/rules.md
+++ b/content/rules/rules.md
@@ -1,10 +1,8 @@
 ---
-title: Rules
+title: What's In The Rules
 weight: 20
 disableToc: false
 chapter: false
 ---
-
-# What's In The Rules
 
 {{% describe-rules version="3" %}}


### PR DESCRIPTION
The `title` attribute for Hugo already defines the `h1` for a page. No need for an additional `h1` in markdown.