### PR TITLE
fix: add 'tx.total_arg_length' to rule 900005 for testing

### DIFF
--- a/content/development/testing.md
+++ b/content/development/testing.md
@@ -139,6 +139,7 @@ SecAction \
     setvar:tx.crs_validate_utf8_encoding=1,\
     setvar:tx.arg_name_length=100,\
     setvar:tx.arg_length=400,\
+    setvar:tx.total_arg_length=64000,\
     setvar:tx.max_file_size=64100,\
     setvar:tx.combined_file_sizes=65535"
 


### PR DESCRIPTION
## Proposed changes

Added `TX` variable `total_arg_length` with value `64000` because rule [920390](https://github.com/coreruleset/coreruleset/blob/main/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf#L881) uses that and its [test](https://github.com/coreruleset/coreruleset/blob/main/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920390.yaml#L29) expects it. Without that a "regular" test is failed.

## Further comment

CRS test uses [modsecurity-crs-docker](https://github.com/coreruleset/modsecurity-crs-docker) image where [activate-rules.sh](https://github.com/coreruleset/modsecurity-crs-docker/blob/a5c93c7416bf3f9b9f6d55056a005399eecdddf4/src/opt/modsecurity/activate-rules.sh#L92) sets that variable.