### PR TITLE
chore: pin Hugo to 0.145.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,5 +23,11 @@
       "depNameTemplate": "coreruleset/coreruleset",
       "datasourceTemplate": "github-releases"
     }
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["gohugoio/hugo"],
+      "allowedVersions": "<=0.145.0"
+    }
   ]
 }


### PR DESCRIPTION
Hugo 0.146.0 includes a new templating engine that isn't yet supported by the Relearn theme.