### PR TITLE
Update CRS version for Google Cloud Armor

### DIFF
--- a/content/1-getting-started/1-4-engine_integration_options.md
+++ b/content/1-getting-started/1-4-engine_integration_options.md
@@ -112,7 +112,7 @@ Fastly has offered CRS as part of their Fastly WAF for several years, but they h
 
 ### Google Cloud Armor
 
-Google integrates CRS into its Cloud Armor WAF offering. Google runs the CRS rules on their own WAF engine. As of fall 2022, Google offers version 3.3.2 of CRS.
+Google integrates CRS into its Cloud Armor WAF offering. Google runs the CRS rules on their own WAF engine. As of April 2026, Google offers version 4.22 of CRS.
 
 To learn more about CRS on Google's Cloud Armor, read [this document from Google](https://cloud.google.com/armor/docs/rule-tuning).
 

--- a/content/1-getting-started/1-4-engine_integration_options.md
+++ b/content/1-getting-started/1-4-engine_integration_options.md
@@ -112,7 +112,7 @@ Fastly has offered CRS as part of their Fastly WAF for several years, but they h
 
 ### Google Cloud Armor
 
-Google integrates CRS into its Cloud Armor WAF offering. Google runs the CRS rules on their own WAF engine. As of April 2026, Google offers version 4.22 of CRS.
+Google integrates CRS into its Cloud Armor WAF offering. Google runs the CRS rules on their own WAF engine. As of April 2026, Google offers version 4.22 of CRS in preview mode (must be enabled specifically), with version 3.3 offered in general release.
 
 To learn more about CRS on Google's Cloud Armor, read [this document from Google](https://cloud.google.com/armor/docs/rule-tuning).
 


### PR DESCRIPTION
Updated the version of CRS offered by Google Cloud Armor from 3.3.2 to 4.22. 

https://docs.cloud.google.com/armor/docs/release-notes#April_06_2026

Unsure if this would need to wait until the update reaches general release