### PR TITLE
fix: rule-exclusions plugins not linking to plugins

### DIFF
--- a/content/2-how-crs-works/2-3-false-positives-and-tuning.md
+++ b/content/2-how-crs-works/2-3-false-positives-and-tuning.md
@@ -391,14 +391,14 @@ SecRule REQUEST_URI "@beginsWith /wordpress/" setvar:tx.crs_exclusions_wordpress
 
 Rule exclusion packages are currently available for the following web applications:
 
-- [cPanel](https://cpanel.net)
-- [DokuWiki](https://www.dokuwiki.org)
-- [Drupal](https://www.drupal.org)
-- [Nextcloud](https://nextcloud.com)
-- [phpBB](https://www.phpbb.com)
-- [phpMyAdmin](https://www.phpmyadmin.net)
-- [WordPress](https://wordpress.org)
-- [XenForo](https://xenforo.com)
+- [cPanel](https://github.com/coreruleset/cpanel-rule-exclusions-plugin)
+- [DokuWiki](https://github.com/coreruleset/dokuwiki-rule-exclusions-plugin)
+- [Drupal](https://github.com/coreruleset/drupal-rule-exclusions-plugin)
+- [Nextcloud](https://github.com/coreruleset/nextcloud-rule-exclusions-plugin)
+- [phpBB](https://github.com/coreruleset/phpbb-rule-exclusions-plugin)
+- [phpMyAdmin](https://github.com/coreruleset/phpmyadmin-rule-exclusions-plugin)
+- [WordPress](https://github.com/coreruleset/wordpress-rule-exclusions-plugin)
+- [XenForo](https://github.com/coreruleset/xenforo-rule-exclusions-plugin)
 
 The CRS project is always looking to work with other communities and individuals to add support for additional web applications. Please get in touch via [GitHub](https://github.com/coreruleset/coreruleset) to discuss writing a rule exclusion package for a specific web application.
 


### PR DESCRIPTION
## Proposed changes

Updates the links in the rule-exclusion documentation about available official plugins to link to the actual plugins and not the official website for the actual application itself.

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... If there are no additional comments, you may remove this section. -->