### PR TITLE
fix: add missing example on enabling plugins per domain

### DIFF
--- a/content/2-how-crs-works/2-3-false-positives-and-tuning.md
+++ b/content/2-how-crs-works/2-3-false-positives-and-tuning.md
@@ -359,6 +359,16 @@ If running multiple web applications, it is highly recommended to enable a rule 
 
 ```apache
 SecRule REQUEST_URI "@beginsWith /wordpress/" setvar:tx.crs_exclusions_wordpress=1...
+
+Or if CRS is running on an reverse-proxy with multiple apps, you can enable plugins per domain using either [SecWebAppID](https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v2.x)#user-content-SecWebAppId) (Unsupported on Coraza):
+```apache
+SecRule WebAppID "@streq wordpress" setvar:tx.crs_exclusions_wordpress=1...
+```
+
+or the Host header:
+```apache
+SecRule REQUEST_HEADERS:Host "@streq wordpress.example.com" setvar:tx.crs_exclusions_wordpress=1...
+
 ```
 {{% /notice %}}
 


### PR DESCRIPTION
## Proposed changes

The rule-exclusion documentation only has an example for enabling plugins per subsite, but not per domain. This doesn't cover cases where a Reverse Proxy is used, and apps are installed on different subdomains.

<!-- Github Tip: adding the text 'Fixes #<issue>' or 'Closes #<issue>' will automatically close the mentioned issue. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... If there are no additional comments, you may remove this section. -->