### PR TITLE
fix: update link to toolquix

### DIFF
--- a/content/6-development/6-7-tools-for-rule-writers.md
+++ b/content/6-development/6-7-tools-for-rule-writers.md
@@ -107,7 +107,7 @@ Encode and decode URL parameters with instant conversion. Helps understand safe 
 
 ### Toolquix Encode/Decode
 
-[https://toolquix.com/encode-decode](https://toolquix.com/encode-decode)
+[https://toolquix.com/tools/encode-decode](https://toolquix.com/tools/encode-decode)
 
 Multi-format encoding tool supporting ASCII to hex, Base32, ROT13, and more. Useful for testing various encoding transformations that attackers might use.
 


### PR DESCRIPTION
## Proposed changes

Fixes 404 error with toolquix, the URL has moved from https://toolquix.com/encode-decode to https://toolquix.com/tools/encode-decode

<!-- Github Tip: adding the text 'Fixes #<issue>' or 'Closes #<issue>' will automatically close the mentioned issue. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... If there are no additional comments, you may remove this section. -->